### PR TITLE
Fix typo in cli.rst

### DIFF
--- a/configuration/cli.rst
+++ b/configuration/cli.rst
@@ -63,5 +63,5 @@ Configuration overview of the command line interface.
   * ``rx-pkts`` - received packets
   * ``tx-pkts`` - transmitted packets
   * ``netns`` - network namespace name
-  * ``vrf`` - Virtual Routing and Aorwarding 
+  * ``vrf`` - Virtual Routing and Forwarding 
   * ``ipoe-type`` - IPoE session type (UP/DHCP)


### PR DESCRIPTION
Found a typo in the cli doc in regards to VRFs. 